### PR TITLE
Feat/ios nullability annotations

### DIFF
--- a/ios/app-swift/app-swift/ViewController.swift
+++ b/ios/app-swift/app-swift/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController {
             NSLog("endpoint changed")
         }
 
-        self.o2mc.setEndpoint(self.endpointNameTextField.text)
+        self.o2mc.setEndpoint(self.endpointNameTextField.text!)
     }
 }
 

--- a/ios/app-swift/app-swift/ViewController.swift
+++ b/ios/app-swift/app-swift/ViewController.swift
@@ -23,6 +23,7 @@ class ViewController: UIViewController {
         }
         self.o2mc = O2MC(endpoint: "http://127.0.0.1:5000/events")
         
+        self.endpointNameTextField.text = self.o2mc.getEndpoint()
     }
 
     override func didReceiveMemoryWarning() {

--- a/ios/app-swift/app-swift/ViewController.swift
+++ b/ios/app-swift/app-swift/ViewController.swift
@@ -38,7 +38,7 @@ class ViewController: UIViewController {
             NSLog("created event")
         }
         
-        self.o2mc.track(self.eventNameTextField.text)
+        self.o2mc.track(self.eventNameTextField.text!)
     }
     
     @IBAction func BtnTouchResetTracking(_ sender: Any) {

--- a/ios/sdk/O2MC/O2MBatchManager.m
+++ b/ios/sdk/O2MC/O2MBatchManager.m
@@ -23,6 +23,7 @@
                         @"osVersion":UIDevice.currentDevice.systemVersion,
                         };
         _dispatcher = [[O2MDispatcher alloc] init :[[NSBundle mainBundle] bundleIdentifier]];
+        _endpoint = @"";
         _eventManager = [O2MEventManager sharedManager];
 
         _logger = [[O2MLogger alloc] initWithTopic:"batchmanager"];

--- a/ios/sdk/O2MC/O2MC.h
+++ b/ios/sdk/O2MC/O2MC.h
@@ -26,13 +26,13 @@
  * Constructs the tracking SDK.
  * @param endpoint http(s) URL which should be publicly reachable
  */
--(nonnull instancetype) initWithEndpoint:(NSString *)endpoint;
+-(nonnull instancetype) initWithEndpoint:(nonnull NSString *)endpoint;
 /**
  * Constructs the tracking SDK.
  * @param dispatchInterval time in seconds between dispatches
  * @param endpoint http(s) URL which should be publicly reachable
  */
--(nonnull instancetype) initWithDispatchInterval:(NSNumber *)dispatchInterval endpoint:(NSString *)endpoint;
+-(nonnull instancetype) initWithDispatchInterval:(nonnull NSNumber *)dispatchInterval endpoint:(nonnull NSString *)endpoint;
 
 #pragma mark - Configuration methods
 
@@ -73,7 +73,7 @@
  *
  * @param uniqueIdentifier unique string which identifies a user.
  */
--(void)setIdentifier:(NSString*) uniqueIdentifier;
+-(void)setIdentifier:(nullable NSString*) uniqueIdentifier;
 
 /**
  * Sets a random session identifier to identify a user.
@@ -86,13 +86,13 @@
  * Essentially adds a new event with the String parameter as name to be dispatched on the next dispatch interval.
  * @param eventName name of tracked event
  */
--(void)track:(NSString*)eventName;
+-(void)track:(nonnull NSString*)eventName;
 /**
  * Tracks an event with additional data.
  * Essentially adds a new event with the String parameter as name and any additonal properties.
  * @param eventName name of tracked event
  * @param properties anything you'd like to keep track of
  */
--(void)trackWithProperties:(NSString*)eventName properties:(NSDictionary*)properties;
+-(void)trackWithProperties:(nonnull NSString*)eventName properties:(nonnull NSDictionary*)properties;
 
 @end

--- a/ios/sdk/O2MC/O2MC.h
+++ b/ios/sdk/O2MC/O2MC.h
@@ -13,7 +13,7 @@
 @interface O2MC : NSObject {
 }
 
-@property (readonly, nonatomic) O2MTagger *tracker;
+@property (readonly, nonatomic, nonnull) O2MTagger *tracker;
 
 
 #pragma mark - Constructors
@@ -21,18 +21,18 @@
 /**
  * Constructs the tracking SDK. NOTE: be sure to set an endpoint.
  */
--(instancetype) init;
+-(nonnull instancetype) init;
 /**
  * Constructs the tracking SDK.
  * @param endpoint http(s) URL which should be publicly reachable
  */
--(instancetype) initWithEndpoint:(NSString *)endpoint;
+-(nonnull instancetype) initWithEndpoint:(NSString *)endpoint;
 /**
  * Constructs the tracking SDK.
  * @param dispatchInterval time in seconds between dispatches
  * @param endpoint http(s) URL which should be publicly reachable
  */
--(instancetype) initWithDispatchInterval:(NSNumber *)dispatchInterval endpoint:(NSString *)endpoint;
+-(nonnull instancetype) initWithDispatchInterval:(NSNumber *)dispatchInterval endpoint:(NSString *)endpoint;
 
 #pragma mark - Configuration methods
 
@@ -40,13 +40,13 @@
  * Returns configured endpoint.
  * @return endpoint
  */
--(NSString*) getEndpoint;
+-(nonnull NSString*) getEndpoint;
 
 /**
  * Configures an end point where the events will be dispatched to.
  * @param endpoint http(s) URL which should be publicly reachable
  */
--(void) setEndpoint:(NSString *)endpoint;
+-(void) setEndpoint:(nonnull NSString *)endpoint;
 /**
  * The max amount of connection retries before stopping dispatching.
  * @param maxRetries retry amount (defaults to 5)

--- a/ios/sdk/O2MC/O2MC.m
+++ b/ios/sdk/O2MC/O2MC.m
@@ -11,17 +11,17 @@
 #import "O2MTagger.h"
 
 @implementation O2MC
--(instancetype) init; {
+-(nonnull instancetype) init; {
     self = [self initWithDispatchInterval:[[NSNumber alloc] initWithInt:10] endpoint:@""];
     return self;
 }
 
--(instancetype) initWithEndpoint:(NSString *)endpoint;  {
+-(nonnull instancetype) initWithEndpoint:(NSString *)endpoint;  {
     self = [self initWithDispatchInterval:[[NSNumber alloc] initWithInt:10] endpoint:endpoint];
     return self;
 }
 
--(instancetype) initWithDispatchInterval:(NSNumber *)dispatchInterval endpoint:(NSString *)endpoint; {
+-(nonnull instancetype) initWithDispatchInterval:(NSNumber *)dispatchInterval endpoint:(NSString *)endpoint; {
      if (self = [super init]) {
          self->_tracker = [[O2MTagger alloc] init:endpoint :dispatchInterval];
 
@@ -31,7 +31,7 @@
      return self;
 }
 
--(NSString*) getEndpoint; {
+-(nonnull NSString*) getEndpoint; {
     return [self->_tracker getEndpoint];
 }
 

--- a/ios/sdk/O2MC/O2MC.m
+++ b/ios/sdk/O2MC/O2MC.m
@@ -16,12 +16,12 @@
     return self;
 }
 
--(nonnull instancetype) initWithEndpoint:(NSString *)endpoint;  {
+-(nonnull instancetype) initWithEndpoint:(nonnull NSString *)endpoint;  {
     self = [self initWithDispatchInterval:[[NSNumber alloc] initWithInt:10] endpoint:endpoint];
     return self;
 }
 
--(nonnull instancetype) initWithDispatchInterval:(NSNumber *)dispatchInterval endpoint:(NSString *)endpoint; {
+-(nonnull instancetype) initWithDispatchInterval:(nonnull NSNumber *)dispatchInterval endpoint:(nonnull NSString *)endpoint; {
      if (self = [super init]) {
          self->_tracker = [[O2MTagger alloc] init:endpoint :dispatchInterval];
 
@@ -35,7 +35,7 @@
     return [self->_tracker getEndpoint];
 }
 
--(void) setEndpoint :(NSString *) endpoint; {
+-(void) setEndpoint:(nonnull NSString *)endpoint; {
     [self->_tracker setEndpoint:endpoint];
 }
 
@@ -51,7 +51,7 @@
     [self->_tracker stop:clearFunnel];
 }
 
--(void)setIdentifier:(NSString*) uniqueIdentifier; {
+-(void)setIdentifier:(nullable NSString*) uniqueIdentifier; {
     [self->_tracker setIdentifier:uniqueIdentifier];
 }
 
@@ -59,11 +59,11 @@
     [self->_tracker setSessionIdentifier];
 }
 
--(void)track :(NSString*)eventName; {
+-(void)track:(nonnull NSString*)eventName; {
     [self->_tracker track:eventName];
 }
 
--(void)trackWithProperties:(NSString*)eventName properties:(NSDictionary*)properties; {
+-(void)trackWithProperties:(nonnull NSString*)eventName properties:(nonnull NSDictionary*)properties; {
     [self->_tracker trackWithProperties:eventName properties:properties];
 }
 


### PR DESCRIPTION
Nullability annotations simplifies the integration between objective-c and swift code. Swift code handles null values differently than objective-c does.