### PR TITLE
Feature/android context tracking

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,31 +1,31 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    defaultConfig {
-        applicationId "io.o2mc.app"
-        minSdkVersion 15
-        targetSdkVersion 26
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  defaultConfig {
+    applicationId "io.o2mc.app"
+    minSdkVersion 15
+    targetSdkVersion 26
+    versionCode 1
+    versionName "1.0"
+    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
+  }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    api 'com.android.support:cardview-v7:27.1.1'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+  implementation fileTree(dir: 'libs', include: ['*.jar'])
+  implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+  implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+  api 'com.android.support:cardview-v7:27.1.1'
+  testImplementation 'junit:junit:4.12'
+  androidTestImplementation 'com.android.support.test:runner:1.0.2'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
-    compile project(path: ':sdk')
+  compile project(path: ':sdk')
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <activity android:name=".ControlActivity"/>
   </application>
 
 </manifest>

--- a/android/app/src/main/java/io/o2mc/app/App.java
+++ b/android/app/src/main/java/io/o2mc/app/App.java
@@ -1,13 +1,7 @@
 package io.o2mc.app;
 
 import android.app.Application;
-import android.util.Log;
 import io.o2mc.sdk.O2MC;
-import io.o2mc.sdk.exceptions.O2MCDeviceException;
-import io.o2mc.sdk.exceptions.O2MCDispatchException;
-import io.o2mc.sdk.exceptions.O2MCEndpointException;
-import io.o2mc.sdk.exceptions.O2MCTrackException;
-import io.o2mc.sdk.interfaces.O2MCExceptionListener;
 
 public class App extends Application {
 

--- a/android/app/src/main/java/io/o2mc/app/ControlActivity.java
+++ b/android/app/src/main/java/io/o2mc/app/ControlActivity.java
@@ -1,0 +1,28 @@
+package io.o2mc.app;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+public class ControlActivity extends AppCompatActivity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_control);
+  }
+
+  /**
+   * Called on 'Stop Tracking' button click
+   */
+  public void onStopTracking(View v) {
+    App.getO2mc().stop();
+  }
+
+  /**
+   * Called on 'Resume Tracking' button click
+   */
+  public void onResumeTracking(View v) {
+    App.getO2mc().resume();
+  }
+}

--- a/android/app/src/main/java/io/o2mc/app/MainActivity.java
+++ b/android/app/src/main/java/io/o2mc/app/MainActivity.java
@@ -1,5 +1,6 @@
 package io.o2mc.app;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -13,6 +14,7 @@ public class MainActivity extends AppCompatActivity {
     setContentView(R.layout.activity_main);
 
     App.getO2mc().track("MainActivityCreated");
+    App.getO2mc().setContextTracking(true);
   }
 
   /**
@@ -36,16 +38,9 @@ public class MainActivity extends AppCompatActivity {
   }
 
   /**
-   * Called on 'Stop Tracking' button click
+   * Called on 'Open' button click
    */
-  public void onStopTracking(View v) {
-    App.getO2mc().stop();
-  }
-
-  /**
-   * Called on 'Resume Tracking' button click
-   */
-  public void onResumeTracking(View v) {
-    App.getO2mc().resume();
+  public void onOpenControls(View v) {
+    startActivity(new Intent(this, ControlActivity.class));
   }
 }

--- a/android/app/src/main/res/layout/activity_control.xml
+++ b/android/app/src/main/res/layout/activity_control.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".ControlActivity"
+    >
+
+  <android.support.v7.widget.CardView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:cardUseCompatPadding="true"
+      >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        >
+
+      <TextView
+          android:id="@+id/titleControls"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="16dp"
+          android:layout_marginRight="16dp"
+          android:layout_marginTop="16dp"
+          android:text="@string/controls"
+          android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+          />
+
+      <Button
+          android:id="@+id/buttonResumeTracking"
+          android:layout_width="match_parent"
+          android:layout_height="75dp"
+          android:layout_margin="16dp"
+          android:onClick="onStopTracking"
+          android:text="@string/stop_tracking"
+          style="@style/Widget.AppCompat.Button.Colored"
+          />
+      <Button
+          android:id="@+id/buttonStopTracking"
+          android:layout_width="match_parent"
+          android:layout_height="75dp"
+          android:layout_marginBottom="16dp"
+          android:layout_marginLeft="16dp"
+          android:layout_marginRight="16dp"
+          android:onClick="onResumeTracking"
+          android:text="@string/resume_tracking"
+          style="@style/Widget.AppCompat.Button.Colored"
+          />
+
+    </LinearLayout>
+  </android.support.v7.widget.CardView>
+</ScrollView>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -6,12 +6,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity"
+    android:padding="16dp"
     >
 
   <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_margin="16dp"
       android:orientation="vertical"
       >
 
@@ -86,23 +86,12 @@
             />
 
         <Button
-            android:id="@+id/buttonResumeTracking"
+            android:id="@+id/buttonOpenControls"
             android:layout_width="match_parent"
             android:layout_height="75dp"
             android:layout_margin="16dp"
-            android:onClick="onStopTracking"
-            android:text="@string/stop_tracking"
-            style="@style/Widget.AppCompat.Button.Colored"
-            />
-        <Button
-            android:id="@+id/buttonStopTracking"
-            android:layout_width="match_parent"
-            android:layout_height="75dp"
-            android:layout_marginBottom="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:onClick="onResumeTracking"
-            android:text="@string/resume_tracking"
+            android:onClick="onOpenControls"
+            android:text="@string/open_controls"
             style="@style/Widget.AppCompat.Button.Colored"
             />
 
@@ -157,3 +146,4 @@
 
   </LinearLayout>
 </ScrollView>
+

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
   <string name="endpoint">http://10.0.2.2:5000/events</string>
   <string name="endpointTitle">Endpoint</string>
   <string name="setEndpoint">Set Endpoint</string>
+  <string name="open_controls">OPEN</string>
 </resources>

--- a/android/appkotlin/src/main/AndroidManifest.xml
+++ b/android/appkotlin/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <activity android:name=".ControlActivity"/>
   </application>
 
 </manifest>

--- a/android/appkotlin/src/main/java/io/o2mc/appkotlin/App.kt
+++ b/android/appkotlin/src/main/java/io/o2mc/appkotlin/App.kt
@@ -11,5 +11,6 @@ class App : Application() {
   // Called on constructor
   init {
     o2mc = O2MC(this, "http://10.0.2.2:5000/events") // init the 'static' field o2mc
+    o2mc.
   }
 }

--- a/android/appkotlin/src/main/java/io/o2mc/appkotlin/App.kt
+++ b/android/appkotlin/src/main/java/io/o2mc/appkotlin/App.kt
@@ -11,6 +11,5 @@ class App : Application() {
   // Called on constructor
   init {
     o2mc = O2MC(this, "http://10.0.2.2:5000/events") // init the 'static' field o2mc
-    o2mc.
   }
 }

--- a/android/appkotlin/src/main/java/io/o2mc/appkotlin/ControlActivity.kt
+++ b/android/appkotlin/src/main/java/io/o2mc/appkotlin/ControlActivity.kt
@@ -1,0 +1,27 @@
+package io.o2mc.appkotlin
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.view.View
+
+class ControlActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_control)
+  }
+
+  /**
+   * Called on 'Stop Tracking' button click
+   */
+  fun onStopTracking(v: View) {
+    App.o2mc.stop()
+  }
+
+  /**
+   * Called on 'Resume Tracking' button click
+   */
+  fun onResumeTracking(v: View) {
+    App.o2mc.resume()
+  }
+}

--- a/android/appkotlin/src/main/java/io/o2mc/appkotlin/MainActivity.kt
+++ b/android/appkotlin/src/main/java/io/o2mc/appkotlin/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.o2mc.appkotlin
 
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.View
@@ -35,16 +36,9 @@ class MainActivity : AppCompatActivity() {
   }
 
   /**
-   * Called on 'Stop Tracking' button click
+   * Called on 'Open' button click
    */
-  fun onStopTracking(v: View) {
-    App.o2mc.stop()
-  }
-
-  /**
-   * Called on 'Resume Tracking' button click
-   */
-  fun onResumeTracking(v: View) {
-    App.o2mc.resume()
+  fun onOpenControls(v: View) {
+    startActivity(Intent(this, ControlActivity::class.java))
   }
 }

--- a/android/appkotlin/src/main/res/layout/activity_control.xml
+++ b/android/appkotlin/src/main/res/layout/activity_control.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".ControlActivity"
+    >
+
+  <android.support.v7.widget.CardView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:cardUseCompatPadding="true"
+      >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        >
+
+      <TextView
+          android:id="@+id/titleControls"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="16dp"
+          android:layout_marginRight="16dp"
+          android:layout_marginTop="16dp"
+          android:text="@string/controls"
+          android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+          />
+
+      <Button
+          android:id="@+id/buttonResumeTracking"
+          android:layout_width="match_parent"
+          android:layout_height="75dp"
+          android:layout_margin="16dp"
+          android:onClick="onStopTracking"
+          android:text="@string/stop_tracking"
+          style="@style/Widget.AppCompat.Button.Colored"
+          />
+      <Button
+          android:id="@+id/buttonStopTracking"
+          android:layout_width="match_parent"
+          android:layout_height="75dp"
+          android:layout_marginBottom="16dp"
+          android:layout_marginLeft="16dp"
+          android:layout_marginRight="16dp"
+          android:onClick="onResumeTracking"
+          android:text="@string/resume_tracking"
+          style="@style/Widget.AppCompat.Button.Colored"
+          />
+
+    </LinearLayout>
+  </android.support.v7.widget.CardView>
+</ScrollView>

--- a/android/appkotlin/src/main/res/layout/activity_main.xml
+++ b/android/appkotlin/src/main/res/layout/activity_main.xml
@@ -6,12 +6,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity"
+    android:padding="16dp"
     >
 
   <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_margin="16dp"
       android:orientation="vertical"
       >
 
@@ -86,23 +86,12 @@
             />
 
         <Button
-            android:id="@+id/buttonResumeTracking"
+            android:id="@+id/buttonOpenControls"
             android:layout_width="match_parent"
             android:layout_height="75dp"
             android:layout_margin="16dp"
-            android:onClick="onStopTracking"
-            android:text="@string/stop_tracking"
-            style="@style/Widget.AppCompat.Button.Colored"
-            />
-        <Button
-            android:id="@+id/buttonStopTracking"
-            android:layout_width="match_parent"
-            android:layout_height="75dp"
-            android:layout_marginBottom="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginRight="16dp"
-            android:onClick="onResumeTracking"
-            android:text="@string/resume_tracking"
+            android:onClick="onOpenControls"
+            android:text="@string/open_controls"
             style="@style/Widget.AppCompat.Button.Colored"
             />
 
@@ -157,3 +146,4 @@
 
   </LinearLayout>
 </ScrollView>
+

--- a/android/appkotlin/src/main/res/values/strings.xml
+++ b/android/appkotlin/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
   <string name="endpoint">http://10.0.2.2:5000/events</string>
   <string name="endpointTitle">Endpoint</string>
   <string name="setEndpoint">Set Endpoint</string>
+  <string name="open_controls">OPEN</string>
 </resources>

--- a/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
@@ -1,8 +1,6 @@
 package io.o2mc.sdk;
 
-import android.app.Activity;
 import android.app.Application;
-import android.os.Bundle;
 import io.o2mc.sdk.interfaces.O2MCExceptionListener;
 import io.o2mc.sdk.util.LogUtil;
 
@@ -15,8 +13,7 @@ import static io.o2mc.sdk.util.LogUtil.LogW;
  */
 // Suppress unused warnings, because the methods in this class are supposed to be used by any
 // app implementing this SDK. They may or may not be used, but that's up to the developer.
-@SuppressWarnings({ "unused", "WeakerAccess" }) public class O2MC
-    implements Application.ActivityLifecycleCallbacks {
+@SuppressWarnings({ "unused", "WeakerAccess" }) public class O2MC {
 
   private static final String TAG = "O2MC";
 
@@ -60,15 +57,6 @@ import static io.o2mc.sdk.util.LogUtil.LogW;
    * @param maxRetries Sets the max amount of retries for generating batches. Helps to reduce cpu usage / battery draining.
    */
   public O2MC(Application app, String endpoint, int dispatchInterval, int maxRetries) {
-    if (app == null) {
-      LogW(TAG, "O2MC: Application (context) provided was null. " +
-          "Manually tracked events will still work, however " +
-          "activity lifecycle callbacks will not be automatically detected.");
-    } else {
-      this.app = app;
-      this.app.registerActivityLifecycleCallbacks(this);
-    }
-
     trackingManager = new TrackingManager();
     trackingManager.init(app, endpoint, dispatchInterval, maxRetries);
   }
@@ -97,6 +85,21 @@ import static io.o2mc.sdk.util.LogUtil.LogW;
       // Stop tracking if the endpoint is invalid. Events won't be sent to the
       // backend anyway, it would only waste the user's data bundle by trying.
       trackingManager.stop();
+    }
+  }
+
+  /**
+   * Enables or disables automatic activity lifecycle event tracking.
+   * If set to true, activity life cycle events like 'onCreate(...)' are automatically
+   * tracked and sent to the backend.
+   *
+   * @param shouldTrackContext true if you wish to track context
+   */
+  public void setContextTracking(boolean shouldTrackContext) {
+    if (shouldTrackContext) {
+      trackingManager.startLifecycleTracking();
+    } else {
+      trackingManager.stopLifecycleTracking();
     }
   }
 
@@ -145,62 +148,6 @@ import static io.o2mc.sdk.util.LogUtil.LogW;
    */
   public void setLogging(boolean shouldLog) {
     LogUtil.setShouldLog(shouldLog);
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivityCreated' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivityCreated(Activity activity, Bundle bundle) {
-    LogD(TAG, "Activity created.");
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivityStarted' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivityStarted(Activity activity) {
-    LogD(TAG, "Activity started.");
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivityStarted' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivityResumed(Activity activity) {
-    LogD(TAG, "Activity resumed.");
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivityPaused' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivityPaused(Activity activity) {
-    LogD(TAG, "Activity resumed.");
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivityStopped' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivityStopped(Activity activity) {
-    LogD(TAG, "Activity stopped.");
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivitySaveInstanceState' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-    LogD(TAG, "Activity saved instance state.");
-  }
-
-  /**
-   * Executed on the Activity lifecycle event 'onActivityDestroyed' of any Activity inside the provided 'App' parameter on initialization of this class.
-   */
-  @Override
-  public void onActivityDestroyed(Activity activity) {
-    LogD(TAG, "Activity destroyed.");
   }
 
   /**

--- a/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
@@ -162,7 +162,7 @@ import static io.o2mc.sdk.util.LogUtil.LogD;
 
   /**
    * Tracks an event with additional data.
-   * Essentially adds a new event with the String parameter as name and any properties in String format.
+   * Essentially adds a new event with the String parameter as name and any properties.
    * Will be dispatched to backend on next dispatch interval.
    *
    * @param eventName name of tracked event

--- a/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
@@ -5,7 +5,6 @@ import io.o2mc.sdk.interfaces.O2MCExceptionListener;
 import io.o2mc.sdk.util.LogUtil;
 
 import static io.o2mc.sdk.util.LogUtil.LogD;
-import static io.o2mc.sdk.util.LogUtil.LogW;
 
 /**
  * This is central point of communication between the SDK and the app implementing it.

--- a/android/sdk/src/main/java/io/o2mc/sdk/TrackingManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/TrackingManager.java
@@ -1,6 +1,8 @@
 package io.o2mc.sdk;
 
+import android.app.Activity;
 import android.app.Application;
+import android.os.Bundle;
 import io.o2mc.sdk.business.DeviceManager;
 import io.o2mc.sdk.business.batch.BatchManager;
 import io.o2mc.sdk.business.event.EventManager;
@@ -28,7 +30,8 @@ import static io.o2mc.sdk.util.LogUtil.LogW;
  * Protecting functions from use by an implementing App prevents accidental usage of methods and
  * therefore prevents incorrect usage of our SDK. Makes the SDK more easy to use and robust.
  */
-public class TrackingManager implements O2MCExceptionNotifier {
+public class TrackingManager
+    implements O2MCExceptionNotifier, Application.ActivityLifecycleCallbacks {
 
   private static final String TAG = "TrackingManager";
 
@@ -44,7 +47,14 @@ public class TrackingManager implements O2MCExceptionNotifier {
 
   public void init(Application application, String endpoint, int dispatchInterval,
       int maxRetries) {
-    this.application = application;
+    if (application == null) {
+      LogW(TAG, "O2MC: Application (context) provided was null. " +
+          "Manually tracked events will still work, however " +
+          "activity lifecycle callbacks will not be automatically detected.");
+    } else {
+      this.application = application;
+      this.application.registerActivityLifecycleCallbacks(this);
+    }
 
     this.deviceManager = new DeviceManager();
     this.eventManager = new EventManager();
@@ -152,5 +162,69 @@ public class TrackingManager implements O2MCExceptionNotifier {
       LogW(TAG, String.format("Exception \"%s\" was fatal. SDK was stopped.",
           e.getClass().getSimpleName()));
     }
+  }
+
+  public void startLifecycleTracking() {
+    // TODO: 8/20/18
+  }
+
+  public void stopLifecycleTracking() {
+    // TODO: 8/20/18
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivityCreated' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivityCreated(Activity activity, Bundle bundle) {
+    LogD(TAG, "Activity created.");
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivityStarted' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivityStarted(Activity activity) {
+    LogD(TAG, "Activity started.");
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivityStarted' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivityResumed(Activity activity) {
+    LogD(TAG, "Activity resumed.");
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivityPaused' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivityPaused(Activity activity) {
+    LogD(TAG, "Activity resumed.");
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivityStopped' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivityStopped(Activity activity) {
+    LogD(TAG, "Activity stopped.");
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivitySaveInstanceState' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
+    LogD(TAG, "Activity saved instance state.");
+  }
+
+  /**
+   * Executed on the Activity lifecycle event 'onActivityDestroyed' of any Activity inside the provided 'App' parameter on initialization of this class.
+   */
+  @Override
+  public void onActivityDestroyed(Activity activity) {
+    LogD(TAG, "Activity destroyed.");
   }
 }

--- a/android/sdk/src/main/java/io/o2mc/sdk/TrackingManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/TrackingManager.java
@@ -53,7 +53,6 @@ public class TrackingManager
           "activity lifecycle callbacks will not be automatically detected.");
     } else {
       this.application = application;
-      this.application.registerActivityLifecycleCallbacks(this);
     }
 
     this.deviceManager = new DeviceManager();
@@ -165,11 +164,11 @@ public class TrackingManager
   }
 
   public void startLifecycleTracking() {
-    // TODO: 8/20/18
+    this.application.registerActivityLifecycleCallbacks(this);
   }
 
   public void stopLifecycleTracking() {
-    // TODO: 8/20/18
+    this.application.unregisterActivityLifecycleCallbacks(this);
   }
 
   /**
@@ -177,7 +176,7 @@ public class TrackingManager
    */
   @Override
   public void onActivityCreated(Activity activity, Bundle bundle) {
-    LogD(TAG, "Activity created.");
+    LogD(TAG, String.format("Activity '%s' created.", activity.getLocalClassName()));
   }
 
   /**
@@ -185,7 +184,7 @@ public class TrackingManager
    */
   @Override
   public void onActivityStarted(Activity activity) {
-    LogD(TAG, "Activity started.");
+    track("ActivityStarted:" + activity.getLocalClassName());
   }
 
   /**
@@ -193,7 +192,7 @@ public class TrackingManager
    */
   @Override
   public void onActivityResumed(Activity activity) {
-    LogD(TAG, "Activity resumed.");
+    LogD(TAG, String.format("Activity '%s' resumed.", activity.getLocalClassName()));
   }
 
   /**
@@ -201,7 +200,7 @@ public class TrackingManager
    */
   @Override
   public void onActivityPaused(Activity activity) {
-    LogD(TAG, "Activity resumed.");
+    LogD(TAG, String.format("Activity '%s' resumed.", activity.getLocalClassName()));
   }
 
   /**
@@ -209,7 +208,7 @@ public class TrackingManager
    */
   @Override
   public void onActivityStopped(Activity activity) {
-    LogD(TAG, "Activity stopped.");
+    track("ActivityStopped:" + activity.getLocalClassName());
   }
 
   /**
@@ -217,7 +216,7 @@ public class TrackingManager
    */
   @Override
   public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-    LogD(TAG, "Activity saved instance state.");
+    LogD(TAG, String.format("Activity '%s' saved instance state.", activity.getLocalClassName()));
   }
 
   /**
@@ -225,6 +224,6 @@ public class TrackingManager
    */
   @Override
   public void onActivityDestroyed(Activity activity) {
-    LogD(TAG, "Activity destroyed.");
+    LogD(TAG, String.format("Activity '%s' destroyed.", activity.getLocalClassName()));
   }
 }

--- a/android/sdk/src/test/java/io/o2mc/sdk/O2MCTest.java
+++ b/android/sdk/src/test/java/io/o2mc/sdk/O2MCTest.java
@@ -42,13 +42,6 @@ public class O2MCTest {
     o2mc.setIdentifier(null);
     o2mc.setSessionIdentifier();
     o2mc.setLogging(false);
-    o2mc.onActivityCreated(null, null);
-    o2mc.onActivityStarted(null);
-    o2mc.onActivityResumed(null);
-    o2mc.onActivityPaused(null);
-    o2mc.onActivityStopped(null);
-    o2mc.onActivitySaveInstanceState(null, null);
-    o2mc.onActivityDestroyed(null);
     o2mc.track(null);
     o2mc.trackWithProperties(null, null);
     o2mc.stop();
@@ -133,48 +126,6 @@ public class O2MCTest {
     executeAllMethods(o2mc);
 
     o2mc.setLogging(false);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivityCreated() {
-    o2mc.onActivityCreated(null, null);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivityStarted() {
-    o2mc.onActivityStarted(null);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivityResumed() {
-    o2mc.onActivityResumed(null);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivityPaused() {
-    o2mc.onActivityPaused(null);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivityStopped() {
-    o2mc.onActivityStopped(null);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivitySaveInstanceState() {
-    o2mc.onActivitySaveInstanceState(null, null);
-    executeAllMethods(o2mc);
-  }
-
-  @Test
-  public void onActivityDestroyed() {
-    o2mc.onActivityDestroyed(null);
     executeAllMethods(o2mc);
   }
 

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -161,11 +161,11 @@ public void track(String eventName) { ... }
 * Will be dispatched to backend on next dispatch interval.
 *
 * @param eventName name of tracked event
-* @param value     anything you'd like to keep track of in String format
+* @param value anything you'd like to keep track of in String format
 */
-public void trackWithProperties(String eventName, String value) { ... }
+public void trackWithProperties(String eventName, Object value) { ... }
 ```
 
 > Invoke function by executing the following statement
 
-`App.getO2mc().trackWithProperties("<eventname>", "<eventvalue>");`
+`App.getO2mc().trackWithProperties("<eventname>", <eventvalue>);`


### PR DESCRIPTION
As is discussed yesterday, it's probably not desirable to log every single lifecycle event in Android (resumeactivity, ondestroyactivity, onstopactivity, etc.).
This gets verbose quickly, so I've chosen to take the following key context events and only automatically track those ones:

- onActivityStarted
This is called right after creation of the activity, and again when the user restarts the activity after stopping. For the last reason, I feel like this is preferable over onActivityCreated.

- onActivityStopped
This is called before the activity is destroyed, and after the activity is paused. It's another key moment in the activity lifecycle.

For now, tracking these two seem the most logical. Maybe onRestart could be useful as well, this is open for debate.
