### PR TITLE
Refactor/ios singletons

### DIFF
--- a/ios/app-obj-c/app-obj-c/AppDelegate.m
+++ b/ios/app-obj-c/app-obj-c/AppDelegate.m
@@ -7,6 +7,7 @@
 //
 
 #import "AppDelegate.h"
+#import "O2MC.h"
 
 @interface AppDelegate ()
 
@@ -16,7 +17,9 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Override point for customization after application launch.
+    // Set endpoint
+    [[O2MC sharedInstance] setEndpoint:@"http://127.0.0.1:5000/events"];
+
     return YES;
 }
 

--- a/ios/app-obj-c/app-obj-c/ViewController.h
+++ b/ios/app-obj-c/app-obj-c/ViewController.h
@@ -8,12 +8,9 @@
 
 #import <os/log.h>
 #import <UIKit/UIKit.h>
-#import "O2MC.h"
-#import "O2MTagger.h"
 
 @interface ViewController : UIViewController
 
-@property (strong, nonatomic) O2MC *O2MC;
 @property (nonatomic, retain) IBOutlet UITextField *endpointTextField;
 @property (nonatomic, retain) IBOutlet UITextField *eventNameTextField;
 @property (nonatomic, retain) os_log_t _logTopic;

--- a/ios/app-obj-c/app-obj-c/ViewController.m
+++ b/ios/app-obj-c/app-obj-c/ViewController.m
@@ -17,8 +17,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    // Init
     self._logTopic = os_log_create("io.o2mc.app-obj-c", "testapp-obj-c");
-    self.O2MC = [[O2MC alloc] initWithEndpoint:@"http://127.0.0.1:5000/events"];
+    self.O2MC = [O2MC sharedInstance];
+
+    // Configure endpoint
+    [self.O2MC setEndpoint:@"http://127.0.0.1:5000/events"];
 
     // Set endpoint textfield with the currently set endpoint.
     [self.endpointTextField setText:[self.O2MC getEndpoint]];

--- a/ios/app-obj-c/app-obj-c/ViewController.m
+++ b/ios/app-obj-c/app-obj-c/ViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "ViewController.h"
+#import "O2MC.h"
 
 @interface ViewController ()
 
@@ -19,13 +20,9 @@
 
     // Init
     self._logTopic = os_log_create("io.o2mc.app-obj-c", "testapp-obj-c");
-    self.O2MC = [O2MC sharedInstance];
-
-    // Configure endpoint
-    [self.O2MC setEndpoint:@"http://127.0.0.1:5000/events"];
 
     // Set endpoint textfield with the currently set endpoint.
-    [self.endpointTextField setText:[self.O2MC getEndpoint]];
+    [self.endpointTextField setText:[[O2MC sharedInstance] getEndpoint]];
 }
 
 
@@ -37,25 +34,26 @@
 - (IBAction)BtnTouchCreateEvent:(id)sender {
     os_log(self._logTopic, "created event");
 
-    [self.O2MC track:self.eventNameTextField.text];
+    [[O2MC sharedInstance] track:self.eventNameTextField.text];
 }
 
 - (IBAction)BtnTouchResetTracking:(id)sender {
     os_log(self._logTopic, "reset tracking");
 
-    [self.O2MC.tracker clearFunnel];
+    [[O2MC sharedInstance] stop];
+    // TODO: implement resume method
 }
 
 - (IBAction)BtnTouchStopTracking:(id)sender {
     os_log(self._logTopic, "stop tracking");
 
-    [self.O2MC stop];
+    [[O2MC sharedInstance] stop];
 }
 
 - (IBAction)InputEndpointChanged:(id)sender; {
     os_log(self._logTopic, "endpoint data changed");
 
-    [self.O2MC.tracker setEndpoint:self.endpointTextField.text];
+    [[O2MC sharedInstance] setEndpoint:self.endpointTextField.text];
 }
 
 

--- a/ios/app-swift/app-swift/AppDelegate.swift
+++ b/ios/app-swift/app-swift/AppDelegate.swift
@@ -15,7 +15,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // Set endpoint
+        O2MC.sharedInstance().setEndpoint("http://127.0.0.1:5000/events")
+
         return true
     }
 

--- a/ios/app-swift/app-swift/ViewController.swift
+++ b/ios/app-swift/app-swift/ViewController.swift
@@ -21,7 +21,8 @@ class ViewController: UIViewController {
         if #available(iOS 10.0, *) {
             self._logTopic = OSLog(subsystem: "io.o2mc.app-swift", category: "testapp-swift")
         }
-        self.o2mc = O2MC(endpoint: "http://127.0.0.1:5000/events")
+        self.o2mc = O2MC.sharedInstance()
+        self.o2mc.setEndpoint("http://127.0.0.1:5000/events")
         
         self.endpointNameTextField.text = self.o2mc.getEndpoint()
     }

--- a/ios/app-swift/app-swift/ViewController.swift
+++ b/ios/app-swift/app-swift/ViewController.swift
@@ -12,7 +12,6 @@ class ViewController: UIViewController {
     
     @IBOutlet weak var eventNameTextField: UITextField!
     @IBOutlet weak var endpointNameTextField: UITextField!
-    var o2mc : O2MC!
     var _logTopic: OSLog!
     
     override func viewDidLoad() {
@@ -21,10 +20,8 @@ class ViewController: UIViewController {
         if #available(iOS 10.0, *) {
             self._logTopic = OSLog(subsystem: "io.o2mc.app-swift", category: "testapp-swift")
         }
-        self.o2mc = O2MC.sharedInstance()
-        self.o2mc.setEndpoint("http://127.0.0.1:5000/events")
         
-        self.endpointNameTextField.text = self.o2mc.getEndpoint()
+        self.endpointNameTextField.text = O2MC.sharedInstance().getEndpoint()
     }
 
     override func didReceiveMemoryWarning() {
@@ -39,7 +36,7 @@ class ViewController: UIViewController {
             NSLog("created event")
         }
         
-        self.o2mc.track(self.eventNameTextField.text!)
+        O2MC.sharedInstance().track(self.eventNameTextField.text!)
     }
     
     @IBAction func BtnTouchResetTracking(_ sender: Any) {
@@ -49,7 +46,7 @@ class ViewController: UIViewController {
             NSLog("reset tracking")
         }
         
-        self.o2mc.tracker.clearFunnel()
+        O2MC.sharedInstance().tracker.clearFunnel()
     }
 
     @IBAction func BtnTouchStopTracking(_ sender: Any) {
@@ -59,7 +56,7 @@ class ViewController: UIViewController {
             NSLog("stop tracking")
         }
 
-        self.o2mc.stop()
+        O2MC.sharedInstance().stop()
     }
 
     @IBAction func InputEndpointChanged(_ sender: Any) {
@@ -69,7 +66,7 @@ class ViewController: UIViewController {
             NSLog("endpoint changed")
         }
 
-        self.o2mc.setEndpoint(self.endpointNameTextField.text!)
+        O2MC.sharedInstance().setEndpoint(self.endpointNameTextField.text!)
     }
 }
 

--- a/ios/sdk/O2MC/O2MBatchManager.h
+++ b/ios/sdk/O2MC/O2MBatchManager.h
@@ -16,7 +16,6 @@
 @property NSString *sessionIdentifier;
 
 
-+ (instancetype)sharedManager;
 /**
  * Starts dispatching with a specific dispatch interval.
  * @param dispatchInterval dispatch time in seconds.

--- a/ios/sdk/O2MC/O2MBatchManager.h
+++ b/ios/sdk/O2MC/O2MBatchManager.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "O2MDispatcherDelegate.h"
+#import "O2MTagger.h"
 
 @interface O2MBatchManager : NSObject <O2MDispatcherDelegate>
 
@@ -15,6 +16,8 @@
 @property NSInteger maxRetries;
 @property NSString *sessionIdentifier;
 
+
+-(instancetype) initWithTagger:(O2MTagger*)tagger;
 
 /**
  * Starts dispatching with a specific dispatch interval.

--- a/ios/sdk/O2MC/O2MBatchManager.m
+++ b/ios/sdk/O2MC/O2MBatchManager.m
@@ -56,16 +56,6 @@
     return self;
 }
 
-+ (instancetype)sharedManager {
-    static O2MBatchManager *sharedO2MBatchManager = nil;
-    static dispatch_once_t onceToken;
-
-    dispatch_once(&onceToken, ^{
-        sharedO2MBatchManager = [[self alloc] init];
-    });
-    return sharedO2MBatchManager;
-}
-
 -(void) dispatchWithInterval :(NSNumber *) dispatchInterval; {
     dispatch_async(_batchQueue, ^{
         if (self->_dispatchTimer) {

--- a/ios/sdk/O2MC/O2MBatchManager.m
+++ b/ios/sdk/O2MC/O2MBatchManager.m
@@ -10,7 +10,6 @@
 
 #import "O2MBatch.h"
 #import "O2MDispatcher.h"
-#import "O2MEventManager.h"
 #import "O2MLogger.h"
 #import "O2MUtil.h"
 #import <UIKit/UIDevice.h>
@@ -24,15 +23,15 @@
 @property (assign, nonatomic, readonly) NSInteger connRetries;
 @property (readonly) NSDictionary *deviceInfo;
 @property O2MDispatcher *dispatcher;
+@property O2MTagger *tagger;
 @property NSTimer * dispatchTimer;
-@property O2MEventManager *eventManager;
 @property (readonly) O2MLogger *logger;
 
 @end
 
 @implementation O2MBatchManager
 
-- (instancetype) init {
+-(instancetype) initWithTagger:(O2MTagger*)tagger; {
     if (self = [super init]) {
         _batches = [[NSMutableArray alloc] init];
         _batchQueue = dispatch_queue_create("io.o2mc.sdk", DISPATCH_QUEUE_SERIAL);
@@ -46,9 +45,9 @@
                         };
         _dispatcher = [[O2MDispatcher alloc] init :[[NSBundle mainBundle] bundleIdentifier]];
         _endpoint = @"";
-        _eventManager = [O2MEventManager sharedManager];
 
         _logger = [[O2MLogger alloc] initWithTopic:"batchmanager"];
+        _tagger = tagger;
 
         // Handle dispatcher's callbacks
         _dispatcher.delegate = self;
@@ -72,14 +71,15 @@
 -(void) createBatch; {
     dispatch_async(self.batchQueue, ^{
         O2MBatch *batch = [[O2MBatch alloc] initWithParams:self->_deviceInfo :self->_batchNumber];
+        NSMutableArray *events = [self->_tagger events];
 
         int i;
-        for (i=0; i< self->_eventManager.events.count; i++) {
-            [batch addEvent:self->_eventManager.events[i]];
+        for (i=0; i< events.count; i++) {
+            [batch addEvent:events[i]];
         }
 
         [self->_batches addObject:batch];
-        [self->_eventManager.events removeAllObjects];
+        [self->_tagger clearFunnel];
     });
 }
 
@@ -103,7 +103,7 @@
                 // Stopping the time based interval loop.
                 [self stop];
             }
-        } else if([self->_eventManager eventCount] > 0) {
+        } else if([self->_tagger.events count] > 0) {
             [self createBatch];
         }
     });

--- a/ios/sdk/O2MC/O2MC.h
+++ b/ios/sdk/O2MC/O2MC.h
@@ -18,21 +18,8 @@
 
 #pragma mark - Constructors
 
-/**
- * Constructs the tracking SDK. NOTE: be sure to set an endpoint.
- */
--(nonnull instancetype) init;
-/**
- * Constructs the tracking SDK.
- * @param endpoint http(s) URL which should be publicly reachable
- */
--(nonnull instancetype) initWithEndpoint:(nonnull NSString *)endpoint;
-/**
- * Constructs the tracking SDK.
- * @param dispatchInterval time in seconds between dispatches
- * @param endpoint http(s) URL which should be publicly reachable
- */
--(nonnull instancetype) initWithDispatchInterval:(nonnull NSNumber *)dispatchInterval endpoint:(nonnull NSString *)endpoint;
++(nonnull instancetype) sharedInstance;
+
 
 #pragma mark - Configuration methods
 

--- a/ios/sdk/O2MC/O2MC.m
+++ b/ios/sdk/O2MC/O2MC.m
@@ -11,16 +11,33 @@
 #import "O2MTagger.h"
 
 @implementation O2MC
+
++(nonnull instancetype) sharedInstance; {
+    static O2MC *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[O2MC alloc] init];
+    });
+
+    return sharedInstance;
+}
+
+/**
+ * Constructs the tracking SDK. NOTE: be sure to set an endpoint.
+ * @return an O2MC instance
+ */
 -(nonnull instancetype) init; {
     self = [self initWithDispatchInterval:[[NSNumber alloc] initWithInt:10] endpoint:@""];
     return self;
 }
 
--(nonnull instancetype) initWithEndpoint:(nonnull NSString *)endpoint;  {
-    self = [self initWithDispatchInterval:[[NSNumber alloc] initWithInt:10] endpoint:endpoint];
-    return self;
-}
-
+/**
+ * Constructs the tracking SDK.
+ * @param dispatchInterval time in seconds between dispatches
+ * @param endpoint http(s) URL which should be publicly reachable
+ * @return an O2MC instance
+ */
 -(nonnull instancetype) initWithDispatchInterval:(nonnull NSNumber *)dispatchInterval endpoint:(nonnull NSString *)endpoint; {
      if (self = [super init]) {
          self->_tracker = [[O2MTagger alloc] init:endpoint :dispatchInterval];

--- a/ios/sdk/O2MC/O2MEventManager.h
+++ b/ios/sdk/O2MC/O2MEventManager.h
@@ -8,12 +8,14 @@
 
 #import <Foundation/Foundation.h>
 #import "Models/O2MEvent.h"
+#import "O2MTagger.h"
 
 @interface O2MEventManager : NSObject
 
 @property (atomic, readonly, strong) NSMutableArray* events;
 
-+ (instancetype)sharedManager;
+-(instancetype) initWithTagger:(O2MTagger*)tagger;
+
 /**
  * Stores an event.
  * @param event event to store

--- a/ios/sdk/O2MC/O2MEventManager.m
+++ b/ios/sdk/O2MC/O2MEventManager.m
@@ -15,17 +15,8 @@
 @end
 
 @implementation O2MEventManager
-+ (instancetype)sharedManager {
-    static O2MEventManager *sharedO2MEventManager = nil;
-    static dispatch_once_t onceToken;
 
-    dispatch_once(&onceToken, ^{
-        sharedO2MEventManager = [[self alloc] init];
-    });
-    return sharedO2MEventManager;
-}
-
--(instancetype) init; {
+-(instancetype) initWithTagger:(O2MTagger*)tagger; {
     if (self = [super init]) {
         _events = [[NSMutableArray alloc] init];
         _eventQueue = dispatch_queue_create("io.o2mc.sdk", DISPATCH_QUEUE_SERIAL);

--- a/ios/sdk/O2MC/O2MTagger.h
+++ b/ios/sdk/O2MC/O2MTagger.h
@@ -63,4 +63,12 @@
  */
 -(void)trackWithProperties:(NSString*)eventName properties:(NSDictionary*)properties;
 
+#pragma mark - Misc methods
+
+/**
+ * Returns currently unprocessed events from the O2MEventManager.
+ * @return Array with events
+ */
+-(NSMutableArray*)events;
+
 @end

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -28,7 +28,7 @@
 -(O2MTagger *) init :(NSString *)endpoint :(NSNumber *)dispatchInterval; {
     self = [super init];
     
-    _batchManager = [[O2MBatchManager alloc] init];
+    _batchManager = [[O2MBatchManager alloc] initWithTagger:self];
     _eventManager = [O2MEventManager sharedManager];
     _logger = [[O2MLogger alloc] initWithTopic:"tagger"];
 
@@ -106,6 +106,12 @@
         [self->_eventManager addEvent: [[O2MEvent alloc] initWithProperties:eventName
                                                                  properties:properties]];
     });
+}
+
+#pragma mark - Misc methods
+
+-(NSMutableArray*)events; {
+    return [self->_eventManager events];
 }
 
 @end

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -28,7 +28,7 @@
 -(O2MTagger *) init :(NSString *)endpoint :(NSNumber *)dispatchInterval; {
     self = [super init];
     
-    _batchManager = [O2MBatchManager sharedManager];
+    _batchManager = [[O2MBatchManager alloc] init];
     _eventManager = [O2MEventManager sharedManager];
     _logger = [[O2MLogger alloc] initWithTopic:"tagger"];
 

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -29,7 +29,7 @@
     self = [super init];
     
     _batchManager = [[O2MBatchManager alloc] initWithTagger:self];
-    _eventManager = [O2MEventManager sharedManager];
+    _eventManager = [[O2MEventManager alloc] initWithTagger:self];
     _logger = [[O2MLogger alloc] initWithTopic:"tagger"];
 
     _tagQueue = dispatch_queue_create("io.o2mc.sdk", DISPATCH_QUEUE_SERIAL);

--- a/ios/sdk/Tests/EventManagerTests.m
+++ b/ios/sdk/Tests/EventManagerTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import "O2MEvent.h"
 #import "O2MEventManager.h"
+#import "O2MTagger.h"
 
 @interface EventManagerTests : XCTestCase
 
@@ -21,7 +22,8 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    self->_eventManager = [O2MEventManager sharedManager];
+    O2MTagger *tagger;
+    self->_eventManager = [[O2MEventManager alloc] initWithTagger:tagger];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Reduced singleton pattern  usage.

**External changes**
* The SDK should now be initialised as a singleton
* Constructors are now private

**Internal changes**

* Remove tight coupling between the BatchManager and the EventManager.
* BatchManager and Eventmanager communicate to the Tagger class using a reference set at the initWithTagger method.